### PR TITLE
Add the ability to sort chapters to the chapter editor. 

### DIFF
--- a/ePubFixer/Forms/BaseForm.Designer.cs
+++ b/ePubFixer/Forms/BaseForm.Designer.cs
@@ -43,6 +43,7 @@
             this.btnClose = new System.Windows.Forms.Button();
             this.btnSave = new System.Windows.Forms.Button();
             this.btnAdd = new System.Windows.Forms.Button();
+            this.btnSort = new System.Windows.Forms.Button();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.statusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.Progress = new System.Windows.Forms.ToolStripProgressBar();
@@ -53,12 +54,12 @@
             this.contextMenu.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // tree
-            // 
+            //
             this.tree.AllowDrop = true;
-            this.tree.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.tree.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tree.BackColor = System.Drawing.SystemColors.Window;
             this.tree.Columns.Add(this.TextCol);
@@ -89,25 +90,25 @@
             this.tree.DragOver += new System.Windows.Forms.DragEventHandler(this.tree_DragOver);
             this.tree.DoubleClick += new System.EventHandler(this.tree_DoubleClick);
             this.tree.MouseHover += new System.EventHandler(this.tree_MouseHover);
-            // 
+            //
             // TextCol
-            // 
+            //
             this.TextCol.Header = "Title";
             this.TextCol.SortOrder = System.Windows.Forms.SortOrder.None;
             this.TextCol.TooltipText = null;
             this.TextCol.Width = 300;
-            // 
+            //
             // CheckCol
-            // 
+            //
             this.CheckCol.Header = "";
             this.CheckCol.MinColumnWidth = 35;
             this.CheckCol.SortOrder = System.Windows.Forms.SortOrder.None;
             this.CheckCol.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this.CheckCol.TooltipText = null;
             this.CheckCol.Width = 35;
-            // 
+            //
             // contextMenu
-            // 
+            //
             this.contextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.addToolStripMenuItem,
             this.removeToolStripMenuItem,
@@ -117,59 +118,59 @@
             this.contextMenu.Name = "contextMenu";
             this.contextMenu.Size = new System.Drawing.Size(186, 114);
             this.contextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenu_Opening);
-            // 
+            //
             // addToolStripMenuItem
-            // 
+            //
             this.addToolStripMenuItem.Name = "addToolStripMenuItem";
             this.addToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
             this.addToolStripMenuItem.Text = "Add";
             this.addToolStripMenuItem.Click += new System.EventHandler(this.addToolStripMenuItem_Click);
-            // 
+            //
             // removeToolStripMenuItem
-            // 
+            //
             this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
             this.removeToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
             this.removeToolStripMenuItem.Text = "Delete";
             this.removeToolStripMenuItem.Click += new System.EventHandler(this.removeToolStripMenuItem_Click);
-            // 
+            //
             // Check
-            // 
+            //
             this.Check.Name = "Check";
             this.Check.Size = new System.Drawing.Size(185, 22);
             this.Check.Text = "Check All Selected";
             this.Check.Click += new System.EventHandler(this.checkAllSelectedToolStripMenuItem_Click);
-            // 
+            //
             // unCheck
-            // 
+            //
             this.unCheck.Name = "unCheck";
             this.unCheck.Size = new System.Drawing.Size(185, 22);
             this.unCheck.Text = "UnCheck All Selected";
             this.unCheck.Click += new System.EventHandler(this.unCheckAllSelectedToolStripMenuItem_Click);
-            // 
+            //
             // previewToolStripMenuItem
-            // 
+            //
             this.previewToolStripMenuItem.Name = "previewToolStripMenuItem";
             this.previewToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
             this.previewToolStripMenuItem.Text = "Preview";
             this.previewToolStripMenuItem.Click += new System.EventHandler(this.previewToolStripMenuItem_Click);
-            // 
+            //
             // nodeTextBox
-            // 
+            //
             this.nodeTextBox.DataPropertyName = "Text";
             this.nodeTextBox.EditEnabled = true;
             this.nodeTextBox.IncrementalSearchEnabled = true;
             this.nodeTextBox.LeftMargin = 5;
             this.nodeTextBox.ParentColumn = this.TextCol;
-            // 
+            //
             // nodeCheckBox
-            // 
+            //
             this.nodeCheckBox.DataPropertyName = "IsChecked";
             this.nodeCheckBox.EditEnabled = true;
             this.nodeCheckBox.LeftMargin = 10;
             this.nodeCheckBox.ParentColumn = this.CheckCol;
-            // 
+            //
             // btnClose
-            // 
+            //
             this.btnClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnClose.Location = new System.Drawing.Point(405, 621);
@@ -179,9 +180,9 @@
             this.btnClose.Text = "Close";
             this.btnClose.UseVisualStyleBackColor = true;
             this.btnClose.Click += new System.EventHandler(this.btnClose_Click);
-            // 
+            //
             // btnSave
-            // 
+            //
             this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnSave.Location = new System.Drawing.Point(324, 621);
             this.btnSave.Name = "btnSave";
@@ -190,9 +191,9 @@
             this.btnSave.Text = "Save";
             this.btnSave.UseVisualStyleBackColor = true;
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
-            // 
+            //
             // btnAdd
-            // 
+            //
             this.btnAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnAdd.Location = new System.Drawing.Point(243, 621);
             this.btnAdd.Name = "btnAdd";
@@ -201,9 +202,20 @@
             this.btnAdd.Text = "Add";
             this.btnAdd.UseVisualStyleBackColor = true;
             this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
-            // 
+            //
+            // btnSort
+            //
+            this.btnSort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSort.Location = new System.Drawing.Point(103, 621);
+            this.btnSort.Name = "btnSort";
+            this.btnSort.Size = new System.Drawing.Size(75, 23);
+            this.btnSort.TabIndex = 2;
+            this.btnSort.Text = "Sort";
+            this.btnSort.UseVisualStyleBackColor = true;
+            this.btnSort.Click += new System.EventHandler(this.btnSort_Click);
+            //
             // statusStrip1
-            // 
+            //
             this.statusStrip1.AutoSize = false;
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.statusLabel,
@@ -214,25 +226,25 @@
             this.statusStrip1.Size = new System.Drawing.Size(492, 24);
             this.statusStrip1.TabIndex = 3;
             this.statusStrip1.Text = "statusStrip1";
-            // 
+            //
             // statusLabel
-            // 
+            //
             this.statusLabel.Name = "statusLabel";
             this.statusLabel.Size = new System.Drawing.Size(223, 19);
             this.statusLabel.Spring = true;
             this.statusLabel.Text = "                                                                        ";
-            // 
+            //
             // Progress
-            // 
+            //
             this.Progress.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.Progress.MarqueeAnimationSpeed = 50;
             this.Progress.Name = "Progress";
             this.Progress.Size = new System.Drawing.Size(150, 18);
             this.Progress.Step = 2;
             this.Progress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
-            // 
+            //
             // cbSplit
-            // 
+            //
             this.cbSplit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.cbSplit.AutoSize = true;
             this.cbSplit.Location = new System.Drawing.Point(12, 627);
@@ -241,14 +253,14 @@
             this.cbSplit.TabIndex = 4;
             this.cbSplit.Text = "Split Chapter on Anchors";
             this.cbSplit.UseVisualStyleBackColor = true;
-            // 
+            //
             // timer
-            // 
+            //
             this.timer.Interval = 5000;
             this.timer.Tick += new System.EventHandler(this.timer_Tick);
-            // 
+            //
             // cbCreateHtmlTOC
-            // 
+            //
             this.cbCreateHtmlTOC.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.cbCreateHtmlTOC.AutoSize = true;
             this.cbCreateHtmlTOC.Checked = global::ePubFixer.Properties.Settings.Default.InsertAnInlineTOC;
@@ -257,11 +269,11 @@
             this.cbCreateHtmlTOC.Name = "cbCreateHtmlTOC";
             this.cbCreateHtmlTOC.Size = new System.Drawing.Size(116, 17);
             this.cbCreateHtmlTOC.TabIndex = 5;
-            this.cbCreateHtmlTOC.Text = "Insert an Html TOC";
+            this.cbCreateHtmlTOC.Text = "Insert a Html TOC";
             this.cbCreateHtmlTOC.UseVisualStyleBackColor = true;
-            // 
+            //
             // BaseForm
-            // 
+            //
             this.AcceptButton = this.btnSave;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -271,6 +283,7 @@
             this.Controls.Add(this.cbCreateHtmlTOC);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.cbSplit);
+            this.Controls.Add(this.btnSort);
             this.Controls.Add(this.btnClose);
             this.Controls.Add(this.btnSave);
             this.Controls.Add(this.btnAdd);
@@ -299,6 +312,7 @@
         private System.Windows.Forms.Button btnClose;
         private System.Windows.Forms.Button btnSave;
         private System.Windows.Forms.Button btnAdd;
+        private System.Windows.Forms.Button btnSort;
         protected System.Windows.Forms.ToolStripMenuItem Check;
         protected System.Windows.Forms.ToolStripMenuItem unCheck;
         protected System.Windows.Forms.ToolStripMenuItem previewToolStripMenuItem;

--- a/ePubFixer/Forms/BaseForm.cs
+++ b/ePubFixer/Forms/BaseForm.cs
@@ -11,6 +11,80 @@ using Aga.Controls.Tree.NodeControls;
 
 namespace ePubFixer
 {
+
+    public static class IListExtensions
+    {
+        //public static void Sort<T>(this IList<T> list)
+        //{
+        //    if (list is List<T> listImpl)
+        //    {
+        //        listImpl.Sort();
+        //    }
+        //    else
+        //    {
+        //        var copy = new List<T>(list);
+        //        list.Sort();
+        //        Copy(copy, 0, list, 0, list.Count);
+        //    }
+        //}
+
+        //public static void Sort<T>(this IList<T> list, Comparison<T> comparison)
+        //{
+        //    if (list is List<T> listImpl)
+        //    {
+        //        listImpl.Sort(comparison);
+        //    }
+        //    else
+        //    { 
+        //        list.Sort(comparison); 
+        //    }
+        //}
+
+        public static void Sort<T>(this IList<T> list, IComparer<T> comparer)
+        {
+            if (list is List<T> listImpl)
+            {
+                listImpl.Sort(comparer);
+            }
+            else
+            {
+                var copy = new List<T>(list);
+                copy.Sort(comparer);
+                list.Clear();
+                foreach (var element in copy)
+                {
+                    list.Add(element);
+                }
+            }
+        }
+
+        //public static void Sort<T>(this IList<T> list, int index, int count,
+        //    IComparer<T> comparer)
+        //{
+        //    if (list is List<T> listImpl)
+        //    {
+        //        listImpl.Sort(index, count, comparer);
+        //    }
+        //    else
+        //    {
+        //        var range = new List<T>(count);
+        //        for (int i = 0; i < count; i++)
+        //        {
+        //            range.Add(list[index + i]);
+        //        }
+        //        range.Sort(comparer);
+        //        Copy(range, 0, list, index, count);
+        //    }
+        //}
+
+        //private static void Copy<T>(IList<T> sourceList, int sourceIndex, IList<T> destinationList, int destinationIndex, int count)
+        //{
+        //    for (int i = 0; i < count; i++)
+        //    {
+        //        destinationList[destinationIndex + i] = sourceList[sourceIndex + i];
+        //    }
+        //}
+    }
     public abstract partial class BaseForm : Form
     {
         #region Fields
@@ -390,6 +464,24 @@ namespace ePubFixer
         {
             throw new NotImplementedException();
         }
+
+        protected virtual void btnSort_Click(object sender, EventArgs e)
+        {
+            // Sort table of contents items by their chapter name
+            tree.BeginUpdate();
+
+            Model.Nodes.Sort(new MySort());
+            
+            tree.EndUpdate();
+        }
+
+        class MySort : IComparer<Node>
+        {
+            public int Compare(Node x, Node y)
+            {
+                return string.Compare(x.Text, y.Text);
+            }
+        }
         #endregion
 
         #region Status Strip Text
@@ -434,7 +526,7 @@ namespace ePubFixer
             timer.Stop();
             tree.NodeMouseClick += new EventHandler<TreeNodeAdvMouseEventArgs>(tree_NodeMouseClick);
             SetSelectedStatusSrc();
-        } 
+        }
         #endregion
 
         #region Get FileNames

--- a/ePubFixer/ePubFixer.csproj
+++ b/ePubFixer/ePubFixer.csproj
@@ -155,9 +155,7 @@
     <Compile Include="Forms\AboutBox.Designer.cs">
       <DependentUpon>AboutBox.cs</DependentUpon>
     </Compile>
-    <Compile Include="Forms\BaseForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Include="Forms\BaseForm.cs" />
     <Compile Include="Forms\BaseForm.Designer.cs">
       <DependentUpon>BaseForm.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
Effectively the title. 

I've been dealing with epub files generated by web2epub from web-serials, where the source-site I'm converting has multiple different stories released together. 

Basically you get a single e-pub file containing multiple series, with the chapters interdigitated:

- Story A: ch 1
- Story B: ch 1
- Story C: ch 1
- Story C: ch 2
- Story B: ch 2
- Story B: ch 3
- Story A: ch 2

etc...

This PR adds a button to the chapter editor that does a one-click natural numeric sort of the chapters in the epub:


- Story A: ch 1
- Story A: ch 2
- Story B: ch 1
- Story B: ch 2
- Story B: ch 3
- Story C: ch 1
- Story C: ch 2

When you have a file that has hundreds of individual chapters, it is miserable to try to do the sorting by hand. This fixes that.